### PR TITLE
Changes for port to macOS

### DIFF
--- a/include/latmrg/FigureOfMerit.h
+++ b/include/latmrg/FigureOfMerit.h
@@ -61,7 +61,7 @@ namespace LatMRG {
       public:
 
       FigureOfMerit() {
-        finished = false;
+        m_finished = false;
       }
 
       /**

--- a/include/latmrg/KorobovLattice.h
+++ b/include/latmrg/KorobovLattice.h
@@ -192,7 +192,8 @@ namespace LatMRG {
       //assert(d <= getMaxDim());
       this->setDim(d);
       Int tmp;
-      NTL::conv(tmp, 1);
+      // the .0 double-literal is needed on some systems to prevent compilation error
+      NTL::conv(tmp, 1.0);
 
       for (int i = 0; i < m_shift; i++) {
         tmp *= m_a;

--- a/include/latmrg/MMRGLattice.h
+++ b/include/latmrg/MMRGLattice.h
@@ -491,7 +491,8 @@ namespace LatMRG {
       this->m_vecNorm.resize(dimension);
       this->m_dualvecNorm.resize(dimension);
 
-      int maxIndiceLac = NTL::conv<int>(m_lac[m_lac.getSize()-1]);
+      // NTL::conv<int>(long long) is not supported, so convert to NTL::ZZ first
+      int maxIndiceLac = NTL::conv<int>(static_cast<NTL::ZZ>(m_lac[m_lac.getSize()-1]));
 
       // building the complete basis until: dimension = max lacunary indice
       //-----------------------------------------------------------------------
@@ -543,7 +544,8 @@ namespace LatMRG {
 
       for (int j = 0; j < m_numberLacIndices; j++) {
         for (int i = 0; i < this->m_order; i++)
-          this->m_wSI[i][j] = tempBasis[ i ][ NTL::conv<int>(m_lac[j]) ];
+          // NTL::conv<int>(long long) is not supported, so convert to NTL::ZZ first
+          this->m_wSI[i][j] = tempBasis[ i ][ NTL::conv<int>(static_cast<NTL::ZZ>(m_lac[j])) ];
       }
 
       /*

--- a/include/latmrg/MMRGLattice.h
+++ b/include/latmrg/MMRGLattice.h
@@ -491,8 +491,7 @@ namespace LatMRG {
       this->m_vecNorm.resize(dimension);
       this->m_dualvecNorm.resize(dimension);
 
-      // NTL::conv<int>(long long) is not supported, so convert to NTL::ZZ first
-      int maxIndiceLac = NTL::conv<int>(static_cast<NTL::ZZ>(m_lac[m_lac.getSize()-1]));
+      int maxIndiceLac = NTL::conv<int>(m_lac[m_lac.getSize()-1]);
 
       // building the complete basis until: dimension = max lacunary indice
       //-----------------------------------------------------------------------
@@ -544,8 +543,7 @@ namespace LatMRG {
 
       for (int j = 0; j < m_numberLacIndices; j++) {
         for (int i = 0; i < this->m_order; i++)
-          // NTL::conv<int>(long long) is not supported, so convert to NTL::ZZ first
-          this->m_wSI[i][j] = tempBasis[ i ][ NTL::conv<int>(static_cast<NTL::ZZ>(m_lac[j])) ];
+          this->m_wSI[i][j] = tempBasis[ i ][ NTL::conv<int>(m_lac[j]) ];
       }
 
       /*

--- a/include/latmrg/MRGLattice.h
+++ b/include/latmrg/MRGLattice.h
@@ -967,7 +967,7 @@ namespace LatMRG {
               statmp[this->m_order-1]);
           // On memorise l'etat suivant.
           for (int i = 0; i < this->m_order-1; i++)
-            NTL::swap (m_sta[i][0], m_sta[i + 1][0]);
+            std::swap (m_sta[i][0], m_sta[i + 1][0]);
           m_sta[this->m_order-1][0] = statmp[this->m_order-1];
           insertion (statmp);
         }

--- a/include/latmrg/ParamReaderExt.h
+++ b/include/latmrg/ParamReaderExt.h
@@ -309,7 +309,7 @@ namespace LatMRG {
   template <typename Int, typename Dbl>
     void ParamReaderExt<Int, Dbl>::readInterval (IntVec & B, IntVec & C, unsigned int & ln, int k)
     {
-      long m1, m2, m3;
+      long long m1, m2, m3;
       for (int i = 0; i < k; i++) {
         this->readNumber3 (B[i], m1, m2, m3, ++ln, 0);
         this->readNumber3 (C[i], m1, m2, m3, ++ln, 0);

--- a/include/latmrg/ParamReaderExt.h
+++ b/include/latmrg/ParamReaderExt.h
@@ -309,7 +309,7 @@ namespace LatMRG {
   template <typename Int, typename Dbl>
     void ParamReaderExt<Int, Dbl>::readInterval (IntVec & B, IntVec & C, unsigned int & ln, int k)
     {
-      long long m1, m2, m3;
+      std::int64_t m1, m2, m3;
       for (int i = 0; i < k; i++) {
         this->readNumber3 (B[i], m1, m2, m3, ++ln, 0);
         this->readNumber3 (C[i], m1, m2, m3, ++ln, 0);

--- a/progs/MRGLattice.cc
+++ b/progs/MRGLattice.cc
@@ -65,7 +65,8 @@ int toVectString(const char* str, Vec& vect, int length) {
     strncpy(to, str+old, j-old);
     to[j-old] = '\0';
     old = j = j+1;
-    if (!strcmp(to, "m")) NTL::conv(vect[i], -1);
+    // the .0 double-literal is needed on some systems to prevent compilation error
+    if (!strcmp(to, "m")) NTL::conv(vect[i], -1.0);
     else NTL::conv(vect[i], to);
   }
   return 0;

--- a/progs/Seek.h
+++ b/progs/Seek.h
@@ -202,8 +202,7 @@ namespace LatMRGSeek {
       std::vector<IntVec> coeffs;
       coeffs.resize(conf.fact[0]->getK());
       for (int i = 0; i < conf.fact[0]->getK(); i++) coeffs[i].resize(
-          // NTL::conv<int>(long long) is not supported, so we convert to ZZ first.
-          NTL::conv<int>(static_cast<NTL::ZZ>(conf.coeff[0][conf.fact[0]->getK()])));
+          NTL::conv<int>(conf.coeff[0][conf.fact[0]->getK()]));
       // The program will not run the maxPeriod function if it is not wanted with
       // this condition
       do {
@@ -341,8 +340,7 @@ namespace LatMRGSeek {
             for (long i = 0; i < conf.fact[k]->getK(); i++) {
               if (conf.fact[k]->get_type() == MRG) {
                 if (conf.search_mode[k] == "pow2") {
-                  // NTL::conv<int>(long long) is not supported, so we convert to ZZ first.
-                  coeffs[i].resize(NTL::conv<int>(static_cast<NTL::ZZ>(conf.coeff[k][conf.fact[k]->getK()])));
+                  coeffs[i].resize(NTL::conv<int>(conf.coeff[k][conf.fact[k]->getK()]));
                   A[i+1] = 0;
                   if (conf.coeff[k][i] >= 0) {
                     for (long j = 0; j < conf.coeff[k][conf.fact[k]->getK()]; j++) {

--- a/progs/Seek.h
+++ b/progs/Seek.h
@@ -202,7 +202,8 @@ namespace LatMRGSeek {
       std::vector<IntVec> coeffs;
       coeffs.resize(conf.fact[0]->getK());
       for (int i = 0; i < conf.fact[0]->getK(); i++) coeffs[i].resize(
-          NTL::conv<int>(conf.coeff[0][conf.fact[0]->getK()]));
+          // NTL::conv<int>(long long) is not supported, so we convert to ZZ first.
+          NTL::conv<int>(static_cast<NTL::ZZ>(conf.coeff[0][conf.fact[0]->getK()])));
       // The program will not run the maxPeriod function if it is not wanted with
       // this condition
       do {
@@ -340,7 +341,8 @@ namespace LatMRGSeek {
             for (long i = 0; i < conf.fact[k]->getK(); i++) {
               if (conf.fact[k]->get_type() == MRG) {
                 if (conf.search_mode[k] == "pow2") {
-                  coeffs[i].resize(NTL::conv<int>(conf.coeff[k][conf.fact[k]->getK()]));
+                  // NTL::conv<int>(long long) is not supported, so we convert to ZZ first.
+                  coeffs[i].resize(NTL::conv<int>(static_cast<NTL::ZZ>(conf.coeff[k][conf.fact[k]->getK()])));
                   A[i+1] = 0;
                   if (conf.coeff[k][i] >= 0) {
                     for (long j = 0; j < conf.coeff[k][conf.fact[k]->getK()]; j++) {


### PR DESCRIPTION
These changes were needed to port LatMRG to my macOS system.

I changed the type of m1, m2, m3 in ParamReaderExt to long long to match the type of ParamReader in latticetester and thus prevent a compilation error on my system.